### PR TITLE
Add unmocked FDC API tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.vscode
 __pycache__
 package-lock.json
 /venv

--- a/tests/test_unmocked.py
+++ b/tests/test_unmocked.py
@@ -18,14 +18,30 @@ class TestFdcAPI(unittest.TestCase):
         self.fdc_id1 = 2057648  # cheddar cheese
         self.fdc_id2 = 534358  # nut n' berry mix
 
+    def test_invalid_food(self):
+        """Trying to retrieve an invalid food returns an error"""
+
+        response = fdc.get_food_by_id(-1)
+
+        self.assertIn("success", response)
+        self.assertIn("error", response)
+        self.assertIn("code", response["error"])
+        self.assertIn("message", response["error"])
+
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"]["code"], "REQUEST_EXCEPTION")
+
     def test_retrieve_food(self):
         """Retrieving a food by FDC ID returns proper results"""
 
         response = fdc.get_food_by_id(self.fdc_id1)
 
+        self.assertIn("success", response)
         self.assertIn("fdcId", response)
         self.assertIn("description", response)
         self.assertIn("ingredients", response)
+
+        self.assertEqual(response["success"], True)
         self.assertEqual(response["fdcId"], self.fdc_id1)
         self.assertEqual(response["description"], "CHEDDAR CHEESE")
 
@@ -33,6 +49,9 @@ class TestFdcAPI(unittest.TestCase):
         """Retrieving a food with specific nutrient IDs returns only nutrients with those IDS."""
 
         response = fdc.get_food_by_id(self.fdc_id1, nutrient_numbers=[301])
+
+        self.assertIn("success", response)
+        self.assertEqual(response["success"], True)
 
         self.assertIn("foodNutrients", response)
         self.assertEqual(len(response["foodNutrients"]), 1)
@@ -48,6 +67,9 @@ class TestFdcAPI(unittest.TestCase):
         ids = [self.fdc_id1, self.fdc_id2]
         response = fdc.get_foods(ids)
 
+        self.assertIn("success", response)
+        self.assertEqual(response["success"], True)
+
         self.assertEqual(len(response), 2)
 
         for idx, food in enumerate(response):
@@ -62,6 +84,9 @@ class TestFdcAPI(unittest.TestCase):
 
         response = fdc.list_foods(per_page=10)
 
+        self.assertIn("success", response)
+        self.assertEqual(response["success"], True)
+
         self.assertLessEqual(len(response), 10)
 
         for food in response:
@@ -73,6 +98,9 @@ class TestFdcAPI(unittest.TestCase):
         "Searching for foods with a search query returns results"
 
         response = fdc.search("cheddar cheese", per_page=10)
+
+        self.assertIn("success", response)
+        self.assertEqual(response["success"], True)
 
         self.assertLessEqual(len(response), 10)
         self.assertIn("totalHits", response)

--- a/tests/test_unmocked.py
+++ b/tests/test_unmocked.py
@@ -48,18 +48,31 @@ class TestFdcAPI(unittest.TestCase):
     def test_retrieve_food_with_nutrient_ids(self):
         """Retrieving a food with specific nutrient IDs returns only nutrients with those IDS."""
 
-        response = fdc.get_food_by_id(self.fdc_id1, nutrient_numbers=[301])
+        nutrient_numbers = [301, 401, 204]
+        response = fdc.get_food_by_id(self.fdc_id1, nutrient_numbers=nutrient_numbers)
 
         self.assertIn("success", response)
         self.assertEqual(response["success"], True)
 
         self.assertIn("foodNutrients", response)
-        self.assertEqual(len(response["foodNutrients"]), 1)
+        self.assertEqual(len(response["foodNutrients"]), 3)
 
-        self.assertIn("nutrient", response["foodNutrients"][0])
-        self.assertIn("number", response["foodNutrients"][0]["nutrient"])
+        for idx, nutrient in enumerate(response["foodNutrients"]):
+            self.assertIn("nutrient", nutrient)
+            self.assertIn("number", nutrient["nutrient"])
 
-        self.assertEqual(response["foodNutrients"][0]["nutrient"]["number"], "301")
+            self.assertEqual(nutrient["nutrient"]["number"], str(nutrient_numbers[idx]))
+
+    def test_retrieve_food_invalid_nutrient_id(self):
+        """Retrieving a food with an invalid nutrient ID returns zero nutrients."""
+
+        response = fdc.get_food_by_id(self.fdc_id1, nutrient_numbers=[-1])
+
+        self.assertIn("success", response)
+        self.assertEqual(response["success"], True)
+
+        self.assertIn("foodNutrients", response)
+        self.assertEqual(len(response["foodNutrients"]), 0)
 
     def test_retrieve_foods(self):
         """Retrieving multiple foods returns proper results"""

--- a/tests/test_unmocked.py
+++ b/tests/test_unmocked.py
@@ -1,0 +1,85 @@
+"""
+Handles unmocked testing.
+"""
+
+import os
+import unittest
+from dotenv import load_dotenv
+import fdc  # pylint: disable=import-error
+
+load_dotenv()
+fdc.set_key(os.getenv("FDC_KEY"))
+
+
+class TestFdcAPI(unittest.TestCase):
+    """Contains test cases for the FoodData Central API."""
+
+    def setUp(self):
+        self.fdc_id1 = 2057648  # cheddar cheese
+        self.fdc_id2 = 534358  # nut n' berry mix
+
+    def test_retrieve_food(self):
+        """Retrieving a food by FDC ID returns proper results"""
+
+        response = fdc.get_food_by_id(self.fdc_id1)
+
+        self.assertIn("fdcId", response)
+        self.assertIn("description", response)
+        self.assertEqual(response["fdcId"], self.fdc_id1)
+        self.assertEqual(response["description"], "CHEDDAR CHEESE")
+
+    def test_retrieve_food_with_nutrient_ids(self):
+        """Retrieving a food with specific nutrient IDs returns only nutrients with those IDS."""
+
+        response = fdc.get_food_by_id(self.fdc_id1, nutrient_numbers=[301])
+
+        self.assertIn("foodNutrients", response)
+        self.assertEqual(len(response["foodNutrients"]), 1)
+
+        self.assertIn("nutrient", response["foodNutrients"][0])
+        self.assertIn("number", response["foodNutrients"][0]["nutrient"])
+
+        self.assertEqual(response["foodNutrients"][0]["nutrient"]["number"], "301")
+
+    def test_retrieve_foods(self):
+        """Retrieving multiple foods returns proper results"""
+
+        ids = [self.fdc_id1, self.fdc_id2]
+        response = fdc.get_foods(ids)
+
+        self.assertEqual(len(response), 2)
+
+        for idx, food in enumerate(response):
+            self.assertIn("fdcId", food)
+            self.assertIn("description", food)
+            self.assertIn("foodNutrients", food)
+            self.assertEqual(food["fdcId"], ids[idx])
+
+    def test_list_foods(self):
+        "Retrieving a list of foods returns results"
+
+        response = fdc.list_foods(per_page=10)
+
+        self.assertLessEqual(len(response), 10)
+
+        for food in response:
+            self.assertIn("fdcId", food)
+            self.assertIn("description", food)
+            self.assertIn("foodNutrients", food)
+
+    def test_search_foods(self):
+        "Searching for foods with a search query returns results"
+
+        response = fdc.search("cheddar cheese", per_page=10)
+
+        self.assertLessEqual(len(response), 10)
+        self.assertIn("totalHits", response)
+        self.assertIn("foods", response)
+
+        self.assertGreaterEqual(response["totalHits"], 1)
+
+        for food in response["foods"]:
+            self.assertIn("fdcId", food)
+            self.assertIn("description", food)
+            self.assertIn("foodNutrients", food)
+            self.assertEqual("cheese" in food["description"].lower(), True)

--- a/tests/test_unmocked.py
+++ b/tests/test_unmocked.py
@@ -25,6 +25,7 @@ class TestFdcAPI(unittest.TestCase):
 
         self.assertIn("fdcId", response)
         self.assertIn("description", response)
+        self.assertIn("ingredients", response)
         self.assertEqual(response["fdcId"], self.fdc_id1)
         self.assertEqual(response["description"], "CHEDDAR CHEESE")
 
@@ -52,6 +53,7 @@ class TestFdcAPI(unittest.TestCase):
         for idx, food in enumerate(response):
             self.assertIn("fdcId", food)
             self.assertIn("description", food)
+            self.assertIn("ingredients", food)
             self.assertIn("foodNutrients", food)
             self.assertEqual(food["fdcId"], ids[idx])
 
@@ -81,5 +83,6 @@ class TestFdcAPI(unittest.TestCase):
         for food in response["foods"]:
             self.assertIn("fdcId", food)
             self.assertIn("description", food)
+            self.assertIn("ingredients", food)
             self.assertIn("foodNutrients", food)
             self.assertEqual("cheese" in food["description"].lower(), True)

--- a/tests/test_unmocked.py
+++ b/tests/test_unmocked.py
@@ -80,7 +80,7 @@ class TestFdcAPI(unittest.TestCase):
             self.assertEqual(food["fdcId"], ids[idx])
 
     def test_list_foods(self):
-        "Retrieving a list of foods returns results"
+        """Retrieving a list of foods returns results"""
 
         response = fdc.list_foods(per_page=10)
 
@@ -95,7 +95,7 @@ class TestFdcAPI(unittest.TestCase):
             self.assertIn("foodNutrients", food)
 
     def test_search_foods(self):
-        "Searching for foods with a search query returns results"
+        """Searching for foods with a search query returns results"""
 
         response = fdc.search("cheddar cheese", per_page=10)
 


### PR DESCRIPTION
Added basic tests for the API. I intend to change the return values of the FDC functions, so I kept the tests basic for now. They check for the features that we'll absolutely need. A good addition to test for may be the presence of the "ingredients" string field, as we'll likely have to parse that field in order to determine which ingredients are incompatible with the user's dietary restrictions.