### PR TITLE
Fix heroku dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^19.0.0",
+    "eslint-plugin-react": "^7.27.0",
     "eslint-plugin-testing-library": "^5.0.0",
     "react-scripts": "^4.0.2"
   }


### PR DESCRIPTION
This is a hotfix for the previous PR, which caused the heroku deployment to fail. Adding the proper dependency for the react eslint configuration should fix the issue.

Changes:
- fix: Added eslint-plugin-react to dev dependencies