### PR TITLE
Fix heroku build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
           "*.js"
         ],
         "rules": {
+          "linebreak-style": "off",
           "react/function-component-definition": "off",
           "react/no-array-index-key": "off",
           "react-hooks/exhaustive-deps": "off",


### PR DESCRIPTION
Fixed a build error on heroku which was a result of the `core.autocrlf` setting of git. I chose to disable the `linebreak-style` rule instead of requiring that everyone ensures this setting is disabled.

Changes:
- fix: Add linebreak-style exclusion to eslint