### PR TITLE
Remove npm build from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run build && python app.py
+web: python app.py


### PR DESCRIPTION
Removed `npm run build` from `Procfile`. Hopefully, this will the be the last fix for this issue.