### PR TITLE
fix: Fixed bug in required field validation

### DIFF
--- a/src/components/HTMLComponents.js
+++ b/src/components/HTMLComponents.js
@@ -68,7 +68,7 @@ export function Input(props) {
   }
 
   const [inputValue, setValue] = useState(initialValue);
-  const [validateRequired, setValidateRequired] = useState(false);
+  const [validateRequired, setValidateRequired] = useState(inputValue.toString().length > 0);
 
   // single-run useEffect to display form errors from flask
   const inputRef = useRef(null);


### PR DESCRIPTION
The `data-required` attribute should only be added if the value is empty (I added that attribute to stop input fields from being marked as invalid before the user has had a chance to type anything in them).

This is a fix that changes a single line, so I'll go ahead and merge it if it passed all the tests.