### PR TITLE
feat: added a workout page for more app interactivity

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,15 @@ def api_search():
     return flask.jsonify(output)
 
 
+@app.route("/workout", methods=["GET", "POST"])
+@login_required
+def workout():
+    """
+    Workout exploration page of the app
+    """
+    return render()
+
+
 @app.route("/logout", methods=["GET", "POST"])
 @login_required
 def logout():

--- a/src/Main.js
+++ b/src/Main.js
@@ -5,6 +5,7 @@ import Landing from './pages/Landing';
 import Login from './pages/Login';
 import Profile from './pages/Profile';
 import Registration from './pages/Registration';
+import Workout from './pages/Workout';
 
 // reads information sent from flask and deletes the element containing it
 function getData(key, json = true) {
@@ -24,6 +25,7 @@ export default function AppRouter() {
   return (
     <Routes>
       <Route path="" element={<Landing />} />
+      <Route path="workout" element={<Workout />} />
       <Route path="app" element={<App />} />
       <Route path="login" element={<Login csrfToken={csrfToken} flashes={flashes} form={form} />} />
       <Route path="registration" element={<Registration csrfToken={csrfToken} flashes={flashes} form={form} />} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -58,6 +58,20 @@ export default function Header() {
         </div>
       </div>
     );
+  } if (pathname === '/workout') {
+    return (
+      <div className="navbar">
+        <div className="nav-left">
+          <Link to="/" className="nav-name">
+            <BotIcon full />
+          </Link>
+        </div>
+        <div className="nav-right">
+          <AnchorButton to="/app" text="Home" />
+          <AnchorButton to="/login" text="Log out" />
+        </div>
+      </div>
+    );
   }
   return (
     <div className="navbar">

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -69,6 +69,10 @@ export default function App() {
       <Header />
       <Container>
         <h2> Find Out Best Overall Diets</h2>
+        <Row>
+          <AnchorButton to="/workout" text="View Workout" />
+        </Row>
+
         <Dropdown
           buttonText="Submit"
           onChange={handleSelect}

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -36,6 +36,9 @@ export default function Profile(props) {
         <h1>Profile</h1>
 
         <Row>
+
+          <AnchorButton to="/workout" text="View Workout" />
+
           <Form token={csrfToken}>
             <Row marginFactor={2}>
               <label htmlFor="gender">Gender:</label>

--- a/src/pages/Workout.js
+++ b/src/pages/Workout.js
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { Container } from '../styles';
+import { Dropdown, Option } from '../components/Dropdown';
+import {
+  AnchorButton, Row,
+} from '../Components';
+import Header from '../components/Header';
+
+// This component will handle the diet lookup feature which will direct user to
+// the best overall Diets.
+export default function App() {
+  const [optionValue, setOptionValue] = useState('');
+  const [option, setOption] = useState('');
+  const [value, setValue] = useState('');
+  const [link, setLink] = useState();
+
+  const handleStretches = (e) => {
+    setOptionValue(e.target.value);
+    // eslint-disable-next-line no-console
+    console.log(e.target.value);
+    if (e.target.value === 'Biceps') {
+      setLink('https://musclewiki.com/Stretches/Male/Biceps');
+    }
+    if (e.target.value === 'Chest') {
+      setLink('https://musclewiki.com/Stretches/Male/Chest');
+    }
+    if (e.target.value === 'Abdominal') {
+      setLink('https://musclewiki.com/Stretches/Male/Abdominals');
+    }
+    if (e.target.value === 'Quads') {
+      setLink('https://musclewiki.com/Stretches/Male/Quads');
+    }
+    if (e.target.value === 'Calves') {
+      setLink('https://musclewiki.com/Stretches/Male/Calves');
+    }
+  };
+  const handleBodyweight = (e) => {
+    setOption(e.target.value);
+    // eslint-disable-next-line no-console
+    console.log(e.target.value);
+    if (e.target.value === 'Biceps') {
+      setLink('https://musclewiki.com/Bodyweight/Male/Biceps');
+    }
+    if (e.target.value === 'Chest') {
+      setLink('https://musclewiki.com/Bodyweight/Male/Chest');
+    }
+    if (e.target.value === 'Abdominal') {
+      setLink('https://musclewiki.com/Bodyweight/Male/Abdominals');
+    }
+    if (e.target.value === 'Quads') {
+      setLink('https://musclewiki.com/Bodyweight/Male/Quads');
+    }
+    if (e.target.value === 'Calves') {
+      setLink('https://musclewiki.com/Bodyweight/Male/Calves');
+    }
+  };
+  const handleBarbells = (e) => {
+    setValue(e.target.value);
+    // eslint-disable-next-line no-console
+    console.log(e.target.value);
+    if (e.target.value === 'Biceps') {
+      setLink('https://musclewiki.com/Barbell/Male/Biceps');
+    }
+    if (e.target.value === 'Chest') {
+      setLink('https://musclewiki.com/Barbell/Male/Chest');
+    }
+    if (e.target.value === 'Abdominal') {
+      setLink('https://musclewiki.com/Barbell/Male/Abdominals');
+    }
+    if (e.target.value === 'Quads') {
+      setLink('https://musclewiki.com/Barbell/Male/Quads');
+    }
+    if (e.target.value === 'Calves') {
+      setLink('https://musclewiki.com/Barbell/Male/Calves');
+    }
+  };
+
+  return (
+    <div>
+      <Header />
+      <Container>
+        <h1>Workout Finder</h1>
+        <h2> Find The Best Workout</h2>
+        <p>
+          Decide and choose the best workout from choices such as
+          stretches, bodyweight, or barbell exercises.
+        </p>
+        <Row>
+          <AnchorButton to="/profile" text="View Profile" />
+        </Row>
+
+        <h3>Stretches</h3>
+        <Dropdown
+          buttonText="Submit"
+          onChange={handleStretches}
+          action={link}
+        >
+          <Option value="Explore Stretch Workouts" />
+          <Option value="Biceps" />
+          <Option value="Chest" />
+          <Option value="Quads" />
+          <Option value="Calves" />
+        </Dropdown>
+        <p>
+          {`You selected ${optionValue}`}
+        </p>
+        <h3>Bodyweight</h3>
+        <Dropdown
+          buttonText="Submit"
+          onChange={handleBodyweight}
+          action={link}
+        >
+          <Option value="Explore Bodyweight Workouts" />
+          <Option value="Biceps" />
+          <Option value="Chest" />
+          <Option value="Quads" />
+          <Option value="Calves" />
+        </Dropdown>
+        <p>
+          {`You selected ${option}`}
+        </p>
+        <h3>Barbells</h3>
+        <Dropdown
+          buttonText="Submit"
+          onChange={handleBarbells}
+          action={link}
+        >
+          <Option value="Explore Bodyweight Workouts" />
+          <Option value="Biceps" />
+          <Option value="Chest" />
+          <Option value="Quads" />
+          <Option value="Calves" />
+        </Dropdown>
+        <p>
+          {`You selected ${value}`}
+        </p>
+        <Row>
+          <AnchorButton to="/login" text="Logout" />
+        </Row>
+      </Container>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a workout page and created a new PR to resolve merge conflicts. I also added the header into the workout page to match the styling of the app for continuity purposes. 

Suggestions:
I have noticed that the header has the logout already on there and I am not in charge of styling but I can suggest maybe taking out the logout buttons for all the regular app pages. Since the logout is already in the header. Another suggestion I have is possibly putting all the buttons in the header to redirect, and only have the save information button in profile.js as a button that appears on the screen for the entire app. Again these are suggestions that can or don't have to be implemented and is left up the choice of the CSS designers or anyone who may want to meet their agile story requirements. 